### PR TITLE
feat: extended ajv formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode
 node_modules
 *.log*
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "typescript.format.semicolons": "remove",
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": true,
+  "typescript.format.insertSpaceBeforeFunctionParenthesis": true
+}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,44 @@ createServer(app).listen(process.env.PORT || 3000)
 
 See how to define your schema with `Type` on [TypeBox documentation](https://github.com/sinclairzx81/typebox#usage).
 
-## Development 💻 
+### Options
+
+You can define a options object on `validateBody` or `validateQuery`. Currently the following options are supported:
+
+- `includeAjvFormats: Boolean`
+
+#### includeAjvFormats
+
+Some formats like `date`, `date-time` or `email` are specified in the current JSONSchema draft, but not included in ajv by default, but provided by the `ajv-formats` package. If one of these formats is needed, you can specify `includeAjvFormats: true` in the options of `validateBody` or `validateQuery` like this:
+
+```ts
+// Body
+validateBody(event, schema, { includeAjvFormats: true })
+
+// Query
+validateQuery(event, schema, { includeAjvFormats: true })
+```
+
+Currently, only the following extended formats are supported for performance and security reasons:
+
+- date-time
+- time
+- date
+- email
+- uri
+- uri-reference
+
+These can be used by custom schemas with the `Type.Unsafe` method or with an inline schema:
+
+```ts
+const bodySchema = Type.Object({
+  optional: Type.Optional(Type.String()),
+  dateTime: Type.String({ format: 'date-time' })
+})
+validateBody(event, bodySchema, { includeAjvFormats: true })
+```
+
+## Development 💻
 
 - Clone this repository
 - Install dependencies using `pnpm install`

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   },
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
-    "@sinclair/typebox": "^0.24.44",
+    "@sinclair/typebox": "^0.25.8",
     "ajv": "^8.11.0",
     "ajv-formats": "^2.1.1",
-    "h3": "^0.8.5"
+    "h3": "^0.8.6"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "latest",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@apideck/better-ajv-errors": "^0.3.6",
     "@sinclair/typebox": "^0.24.44",
     "ajv": "^8.11.0",
+    "ajv-formats": "^2.1.1",
     "h3": "^0.8.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ specifiers:
   '@types/supertest': latest
   '@vitest/coverage-c8': latest
   ajv: ^8.11.0
+  ajv-formats: ^2.1.1
   eslint: latest
   h3: ^0.8.5
   standard-version: latest
@@ -19,18 +20,19 @@ dependencies:
   '@apideck/better-ajv-errors': 0.3.6_ajv@8.11.0
   '@sinclair/typebox': 0.24.44
   ajv: 8.11.0
+  ajv-formats: 2.1.1_ajv@8.11.0
   h3: 0.8.5
 
 devDependencies:
-  '@nuxtjs/eslint-config-typescript': 11.0.0_wyqvi574yv7oiwfeinomdzmc3m
+  '@nuxtjs/eslint-config-typescript': 11.0.0_rmayb2veg2btbq6mbmnyivgasy
   '@types/supertest': 2.0.12
-  '@vitest/coverage-c8': 0.24.3
-  eslint: 8.26.0
+  '@vitest/coverage-c8': 0.25.1
+  eslint: 8.27.0
   standard-version: 9.5.0
-  supertest: 6.3.0
+  supertest: 6.3.1
   typescript: 4.8.4
   unbuild: 0.9.4
-  vitest: 0.24.3
+  vitest: 0.25.1
 
 packages:
 
@@ -389,36 +391,36 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@nuxtjs/eslint-config-typescript/11.0.0_wyqvi574yv7oiwfeinomdzmc3m:
+  /@nuxtjs/eslint-config-typescript/11.0.0_rmayb2veg2btbq6mbmnyivgasy:
     resolution: {integrity: sha512-hmFjGtXT524ql8eTbK8BaRkamcXB6Z8YOW8nSQhosTP6oBw9WtOFUeWr7holyE278UhOmx+wDFG90BnyM9D+UA==}
     peerDependencies:
       eslint: ^8.23.0
     dependencies:
-      '@nuxtjs/eslint-config': 11.0.0_3kfy4n2yrit4yqblnsz4zmqkii
-      '@typescript-eslint/eslint-plugin': 5.36.2_gxwdnffpiv5ciyba5kqrxpisdq
-      '@typescript-eslint/parser': 5.36.2_wyqvi574yv7oiwfeinomdzmc3m
-      eslint: 8.26.0
-      eslint-import-resolver-typescript: 3.5.1_mynvxvmq5qtyojffiqgev4x7mm
-      eslint-plugin-import: 2.26.0_3kfy4n2yrit4yqblnsz4zmqkii
+      '@nuxtjs/eslint-config': 11.0.0_sb4rxkif7oth5qbnhmla3dv7ui
+      '@typescript-eslint/eslint-plugin': 5.36.2_vuwopgfzlsnnlkebtvgtpoaujq
+      '@typescript-eslint/parser': 5.36.2_rmayb2veg2btbq6mbmnyivgasy
+      eslint: 8.27.0
+      eslint-import-resolver-typescript: 3.5.1_dcpv4nbdr5ks2h5677xdltrk6e
+      eslint-plugin-import: 2.26.0_sb4rxkif7oth5qbnhmla3dv7ui
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
 
-  /@nuxtjs/eslint-config/11.0.0_3kfy4n2yrit4yqblnsz4zmqkii:
+  /@nuxtjs/eslint-config/11.0.0_sb4rxkif7oth5qbnhmla3dv7ui:
     resolution: {integrity: sha512-o4zFOpU8gJgwrC/gLE7c2E0XEjkv2fEixCGG1y+dZYzBPyzTorkQmfxskSF3WRXcZkpkS9uUYlRkeOSdYB7z0w==}
     peerDependencies:
       eslint: ^8.23.0
     dependencies:
-      eslint: 8.26.0
-      eslint-config-standard: 17.0.0_6cmbzicqlx7slyu26nv6kzji4y
-      eslint-plugin-import: 2.26.0_3kfy4n2yrit4yqblnsz4zmqkii
-      eslint-plugin-n: 15.2.5_eslint@8.26.0
-      eslint-plugin-node: 11.1.0_eslint@8.26.0
-      eslint-plugin-promise: 6.0.1_eslint@8.26.0
-      eslint-plugin-unicorn: 43.0.2_eslint@8.26.0
-      eslint-plugin-vue: 9.4.0_eslint@8.26.0
+      eslint: 8.27.0
+      eslint-config-standard: 17.0.0_yqvjeq2xzul43p26zlvfoiu3rm
+      eslint-plugin-import: 2.26.0_sb4rxkif7oth5qbnhmla3dv7ui
+      eslint-plugin-n: 15.2.5_eslint@8.27.0
+      eslint-plugin-node: 11.1.0_eslint@8.27.0
+      eslint-plugin-promise: 6.0.1_eslint@8.27.0
+      eslint-plugin-unicorn: 43.0.2_eslint@8.27.0
+      eslint-plugin-vue: 9.4.0_eslint@8.27.0
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-typescript
@@ -592,7 +594,7 @@ packages:
       '@types/superagent': 4.1.15
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.36.2_gxwdnffpiv5ciyba5kqrxpisdq:
+  /@typescript-eslint/eslint-plugin/5.36.2_vuwopgfzlsnnlkebtvgtpoaujq:
     resolution: {integrity: sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -603,12 +605,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.2_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/parser': 5.36.2_rmayb2veg2btbq6mbmnyivgasy
       '@typescript-eslint/scope-manager': 5.36.2
-      '@typescript-eslint/type-utils': 5.36.2_wyqvi574yv7oiwfeinomdzmc3m
-      '@typescript-eslint/utils': 5.36.2_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/type-utils': 5.36.2_rmayb2veg2btbq6mbmnyivgasy
+      '@typescript-eslint/utils': 5.36.2_rmayb2veg2btbq6mbmnyivgasy
       debug: 4.3.4
-      eslint: 8.26.0
+      eslint: 8.27.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
@@ -619,7 +621,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.36.2_wyqvi574yv7oiwfeinomdzmc3m:
+  /@typescript-eslint/parser/5.36.2_rmayb2veg2btbq6mbmnyivgasy:
     resolution: {integrity: sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -633,7 +635,7 @@ packages:
       '@typescript-eslint/types': 5.36.2
       '@typescript-eslint/typescript-estree': 5.36.2_typescript@4.8.4
       debug: 4.3.4
-      eslint: 8.26.0
+      eslint: 8.27.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
@@ -647,7 +649,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.36.2
     dev: true
 
-  /@typescript-eslint/type-utils/5.36.2_wyqvi574yv7oiwfeinomdzmc3m:
+  /@typescript-eslint/type-utils/5.36.2_rmayb2veg2btbq6mbmnyivgasy:
     resolution: {integrity: sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -658,9 +660,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.36.2_typescript@4.8.4
-      '@typescript-eslint/utils': 5.36.2_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/utils': 5.36.2_rmayb2veg2btbq6mbmnyivgasy
       debug: 4.3.4
-      eslint: 8.26.0
+      eslint: 8.27.0
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -686,14 +688,14 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.36.2_wyqvi574yv7oiwfeinomdzmc3m:
+  /@typescript-eslint/utils/5.36.2_rmayb2veg2btbq6mbmnyivgasy:
     resolution: {integrity: sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -703,9 +705,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.36.2
       '@typescript-eslint/types': 5.36.2
       '@typescript-eslint/typescript-estree': 5.36.2_typescript@4.8.4
-      eslint: 8.26.0
+      eslint: 8.27.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.26.0
+      eslint-utils: 3.0.0_eslint@8.27.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -719,11 +721,11 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@vitest/coverage-c8/0.24.3:
-    resolution: {integrity: sha512-tAmMyHxWYnAwGeJb7QgTuEX8aLasTg4X1/6INobXa/7wYGEJ28CACFO5iLn1HzFVPoLvhsS3luQjiflGjjSMRQ==}
+  /@vitest/coverage-c8/0.25.1:
+    resolution: {integrity: sha512-gpl5QNaNeIN0mfRiosCqBFoZcizb5GA458TDnOQXkGDc4kklazxn70u9evGfV62wiiAUfGGebgRhxlBkAa6m6g==}
     dependencies:
       c8: 7.12.0
-      vitest: 0.24.3
+      vitest: 0.25.1
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -753,6 +755,11 @@ packages:
       acorn: 8.8.0
     dev: true
 
+  /acorn-walk/8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
   /acorn/8.8.0:
     resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
     engines: {node: '>=0.4.0'}
@@ -762,6 +769,17 @@ packages:
   /add-stream/1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
     dev: true
+
+  /ajv-formats/2.1.1_ajv@8.11.0:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.11.0
+    dev: false
 
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -902,7 +920,7 @@ packages:
   /builtins/5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.3.7
+      semver: 7.3.8
     dev: true
 
   /c8/7.12.0:
@@ -1922,7 +1940,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-standard/17.0.0_6cmbzicqlx7slyu26nv6kzji4y:
+  /eslint-config-standard/17.0.0_yqvjeq2xzul43p26zlvfoiu3rm:
     resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
     peerDependencies:
       eslint: ^8.0.1
@@ -1930,10 +1948,10 @@ packages:
       eslint-plugin-n: ^15.0.0
       eslint-plugin-promise: ^6.0.0
     dependencies:
-      eslint: 8.26.0
-      eslint-plugin-import: 2.26.0_3kfy4n2yrit4yqblnsz4zmqkii
-      eslint-plugin-n: 15.2.5_eslint@8.26.0
-      eslint-plugin-promise: 6.0.1_eslint@8.26.0
+      eslint: 8.27.0
+      eslint-plugin-import: 2.26.0_sb4rxkif7oth5qbnhmla3dv7ui
+      eslint-plugin-n: 15.2.5_eslint@8.27.0
+      eslint-plugin-promise: 6.0.1_eslint@8.27.0
     dev: true
 
   /eslint-import-resolver-node/0.3.6:
@@ -1945,7 +1963,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/3.5.1_mynvxvmq5qtyojffiqgev4x7mm:
+  /eslint-import-resolver-typescript/3.5.1_dcpv4nbdr5ks2h5677xdltrk6e:
     resolution: {integrity: sha512-U7LUjNJPYjNsHvAUAkt/RU3fcTSpbllA0//35B4eLYTX74frmOepbt7F7J3D1IGtj9k21buOpaqtDd4ZlS/BYQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -1954,8 +1972,8 @@ packages:
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.10.0
-      eslint: 8.26.0
-      eslint-plugin-import: 2.26.0_3kfy4n2yrit4yqblnsz4zmqkii
+      eslint: 8.27.0
+      eslint-plugin-import: 2.26.0_sb4rxkif7oth5qbnhmla3dv7ui
       get-tsconfig: 4.2.0
       globby: 13.1.2
       is-core-module: 2.10.0
@@ -1983,38 +2001,38 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.2_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/parser': 5.36.2_rmayb2veg2btbq6mbmnyivgasy
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.1_mynvxvmq5qtyojffiqgev4x7mm
+      eslint-import-resolver-typescript: 3.5.1_dcpv4nbdr5ks2h5677xdltrk6e
       find-up: 2.1.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-es/3.0.1_eslint@8.26.0:
+  /eslint-plugin-es/3.0.1_eslint@8.27.0:
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.26.0
+      eslint: 8.27.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-es/4.1.0_eslint@8.26.0:
+  /eslint-plugin-es/4.1.0_eslint@8.27.0:
     resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.26.0
+      eslint: 8.27.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-import/2.26.0_3kfy4n2yrit4yqblnsz4zmqkii:
+  /eslint-plugin-import/2.26.0_sb4rxkif7oth5qbnhmla3dv7ui:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2024,12 +2042,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.2_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/parser': 5.36.2_rmayb2veg2btbq6mbmnyivgasy
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.26.0
+      eslint: 8.27.0
       eslint-import-resolver-node: 0.3.6
       eslint-module-utils: 2.7.3_7liths4w263er5tix7tpkwznyq
       has: 1.0.3
@@ -2045,31 +2063,31 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-n/15.2.5_eslint@8.26.0:
+  /eslint-plugin-n/15.2.5_eslint@8.27.0:
     resolution: {integrity: sha512-8+BYsqiyZfpu6NXmdLOXVUfk8IocpCjpd8nMRRH0A9ulrcemhb2VI9RSJMEy5udx++A/YcVPD11zT8hpFq368g==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
       builtins: 5.0.1
-      eslint: 8.26.0
-      eslint-plugin-es: 4.1.0_eslint@8.26.0
-      eslint-utils: 3.0.0_eslint@8.26.0
+      eslint: 8.27.0
+      eslint-plugin-es: 4.1.0_eslint@8.27.0
+      eslint-utils: 3.0.0_eslint@8.27.0
       ignore: 5.2.0
       is-core-module: 2.10.0
       minimatch: 3.1.2
       resolve: 1.22.1
-      semver: 7.3.7
+      semver: 7.3.8
     dev: true
 
-  /eslint-plugin-node/11.1.0_eslint@8.26.0:
+  /eslint-plugin-node/11.1.0_eslint@8.27.0:
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=5.16.0'
     dependencies:
-      eslint: 8.26.0
-      eslint-plugin-es: 3.0.1_eslint@8.26.0
+      eslint: 8.27.0
+      eslint-plugin-es: 3.0.1_eslint@8.27.0
       eslint-utils: 2.1.0
       ignore: 5.2.0
       minimatch: 3.1.2
@@ -2077,16 +2095,16 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-promise/6.0.1_eslint@8.26.0:
+  /eslint-plugin-promise/6.0.1_eslint@8.27.0:
     resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.26.0
+      eslint: 8.27.0
     dev: true
 
-  /eslint-plugin-unicorn/43.0.2_eslint@8.26.0:
+  /eslint-plugin-unicorn/43.0.2_eslint@8.27.0:
     resolution: {integrity: sha512-DtqZ5mf/GMlfWoz1abIjq5jZfaFuHzGBZYIeuJfEoKKGWRHr2JiJR+ea+BF7Wx2N1PPRoT/2fwgiK1NnmNE3Hg==}
     engines: {node: '>=14.18'}
     peerDependencies:
@@ -2095,8 +2113,8 @@ packages:
       '@babel/helper-validator-identifier': 7.18.6
       ci-info: 3.3.2
       clean-regexp: 1.0.0
-      eslint: 8.26.0
-      eslint-utils: 3.0.0_eslint@8.26.0
+      eslint: 8.27.0
+      eslint-utils: 3.0.0_eslint@8.27.0
       esquery: 1.4.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.0
@@ -2105,23 +2123,23 @@ packages:
       read-pkg-up: 7.0.1
       regexp-tree: 0.1.24
       safe-regex: 2.1.1
-      semver: 7.3.7
+      semver: 7.3.8
       strip-indent: 3.0.0
     dev: true
 
-  /eslint-plugin-vue/9.4.0_eslint@8.26.0:
+  /eslint-plugin-vue/9.4.0_eslint@8.27.0:
     resolution: {integrity: sha512-Nzz2QIJ8FG+rtJaqT/7/ru5ie2XgT9KCudkbN0y3uFYhQ41nuHEaboLAiqwMcK006hZPQv/rVMRhUIwEGhIvfQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.26.0
-      eslint-utils: 3.0.0_eslint@8.26.0
+      eslint: 8.27.0
+      eslint-utils: 3.0.0_eslint@8.27.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.0.10
-      semver: 7.3.7
-      vue-eslint-parser: 9.1.0_eslint@8.26.0
+      semver: 7.3.8
+      vue-eslint-parser: 9.1.0_eslint@8.27.0
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -2150,13 +2168,13 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@8.26.0:
+  /eslint-utils/3.0.0_eslint@8.27.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.26.0
+      eslint: 8.27.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -2175,8 +2193,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint/8.26.0:
-    resolution: {integrity: sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==}
+  /eslint/8.27.0:
+    resolution: {integrity: sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
@@ -2191,7 +2209,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.26.0
+      eslint-utils: 3.0.0_eslint@8.27.0
       eslint-visitor-keys: 3.3.0
       espree: 9.4.0
       esquery: 1.4.0
@@ -3297,7 +3315,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.10.0
-      semver: 7.3.7
+      semver: 7.3.8
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -3783,6 +3801,14 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
+  /semver/7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
   /shebang-command/2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3925,6 +3951,7 @@ packages:
 
   /stringify-package/1.0.1:
     resolution: {integrity: sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==}
+    deprecated: This module is not used anymore, and has been replaced by @npmcli/package-json
     dev: true
 
   /strip-ansi/6.0.1:
@@ -3957,8 +3984,8 @@ packages:
       acorn: 8.8.0
     dev: true
 
-  /superagent/8.0.0:
-    resolution: {integrity: sha512-iudipXEel+SzlP9y29UBWGDjB+Zzag+eeA1iLosaR2YHBRr1Q1kC29iBrF2zIVD9fqVbpZnXkN/VJmwFMVyNWg==}
+  /superagent/8.0.3:
+    resolution: {integrity: sha512-oBC+aNsCjzzjmO5AOPBPFS+Z7HPzlx+DQr/aHwM08kI+R24gsDmAS1LMfza1fK+P+SKlTAoNZpOvooE/pRO1HA==}
     engines: {node: '>=6.4.0 <13 || >=14'}
     dependencies:
       component-emitter: 1.3.0
@@ -3970,18 +3997,17 @@ packages:
       methods: 1.1.2
       mime: 2.6.0
       qs: 6.11.0
-      readable-stream: 3.6.0
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /supertest/6.3.0:
-    resolution: {integrity: sha512-QgWju1cNoacP81Rv88NKkQ4oXTzGg0eNZtOoxp1ROpbS4OHY/eK5b8meShuFtdni161o5X0VQvgo7ErVyKK+Ow==}
+  /supertest/6.3.1:
+    resolution: {integrity: sha512-hRohNeIfk/cA48Cxpa/w48hktP6ZaRqXb0QV5rLvW0C7paRsBU3Q5zydzYrslOJtj/gd48qx540jKtcs6vG1fQ==}
     engines: {node: '>=6.4.0'}
     dependencies:
       methods: 1.1.2
-      superagent: 8.0.0
+      superagent: 8.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4294,8 +4320,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.24.3:
-    resolution: {integrity: sha512-aM0auuPPgMSstWvr851hB74g/LKaKBzSxcG3da7ejfZbx08Y21JpZmbmDYrMTCGhVZKqTGwzcnLMwyfz2WzkhQ==}
+  /vitest/0.25.1:
+    resolution: {integrity: sha512-eH74h6MkuEgsqR4mAQZeMK9O0PROiKY+i+1GMz/fBi5A3L2ml5U7JQs7LfPU7+uWUziZyLHagl+rkyfR8SLhlA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -4319,9 +4345,12 @@ packages:
       '@types/chai': 4.3.3
       '@types/chai-subset': 1.3.3
       '@types/node': 18.6.4
+      acorn: 8.8.0
+      acorn-walk: 8.2.0
       chai: 4.3.6
       debug: 4.3.4
       local-pkg: 0.4.2
+      source-map: 0.6.1
       strip-literal: 0.4.2
       tinybench: 2.3.1
       tinypool: 0.3.0
@@ -4335,20 +4364,20 @@ packages:
       - terser
     dev: true
 
-  /vue-eslint-parser/9.1.0_eslint@8.26.0:
+  /vue-eslint-parser/9.1.0_eslint@8.27.0:
     resolution: {integrity: sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
       debug: 4.3.4
-      eslint: 8.26.0
+      eslint: 8.27.0
       eslint-scope: 7.1.1
       eslint-visitor-keys: 3.3.0
       espree: 9.4.0
       esquery: 1.4.0
       lodash: 4.17.21
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,13 +3,13 @@ lockfileVersion: 5.4
 specifiers:
   '@apideck/better-ajv-errors': ^0.3.6
   '@nuxtjs/eslint-config-typescript': latest
-  '@sinclair/typebox': ^0.24.44
+  '@sinclair/typebox': ^0.25.8
   '@types/supertest': latest
   '@vitest/coverage-c8': latest
   ajv: ^8.11.0
   ajv-formats: ^2.1.1
   eslint: latest
-  h3: ^0.8.5
+  h3: ^0.8.6
   standard-version: latest
   supertest: latest
   typescript: latest
@@ -18,10 +18,10 @@ specifiers:
 
 dependencies:
   '@apideck/better-ajv-errors': 0.3.6_ajv@8.11.0
-  '@sinclair/typebox': 0.24.44
+  '@sinclair/typebox': 0.25.8
   ajv: 8.11.0
   ajv-formats: 2.1.1_ajv@8.11.0
-  h3: 0.8.5
+  h3: 0.8.6
 
 devDependencies:
   '@nuxtjs/eslint-config-typescript': 11.0.0_rmayb2veg2btbq6mbmnyivgasy
@@ -531,8 +531,8 @@ packages:
       rollup: 3.2.3
     dev: true
 
-  /@sinclair/typebox/0.24.44:
-    resolution: {integrity: sha512-ka0W0KN5i6LfrSocduwliMMpqVgohtPFidKdMEOUjoOFCHcOOYkKsPRxfs5f15oPNHTm6ERAm0GV/+/LTKeiWg==}
+  /@sinclair/typebox/0.25.8:
+    resolution: {integrity: sha512-/7GXgMOCfnxpIov52cPetqQ7bxRBaTBJAgp04Se2UQB1J0vUfEOIMpn63cLc3S5JXDUflCWxELKDV8eiPpmUTQ==}
     dev: false
 
   /@types/chai-subset/1.3.3:
@@ -614,7 +614,7 @@ packages:
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -2614,8 +2614,8 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
-  /h3/0.8.5:
-    resolution: {integrity: sha512-A+rVzJ+31e67JJzlRf2Ycphu/mvl2qknbpch38xRfrs9HuGSKTtOWuzPnpgaEGIfnzuD/BsDOfhQLJevXEm3ag==}
+  /h3/0.8.6:
+    resolution: {integrity: sha512-CSWNOKa3QGo67rFU2PhbFTp0uPJtilNji2Z0pMiSRQt3+OkIW0u3E1WMJqIycLqaTgb9JyFqH/S4mcTyyGtvyQ==}
     dependencies:
       cookie-es: 0.5.0
       destr: 1.2.0
@@ -3793,14 +3793,6 @@ packages:
     hasBin: true
     dev: true
 
-  /semver/7.3.7:
-    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: true
-
   /semver/7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
     engines: {node: '>=10'}
@@ -3907,7 +3899,7 @@ packages:
       figures: 3.2.0
       find-up: 5.0.0
       git-semver-tags: 4.1.1
-      semver: 7.3.7
+      semver: 7.3.8
       stringify-package: 1.0.1
       yargs: 16.2.0
     dev: true

--- a/src/body.ts
+++ b/src/body.ts
@@ -1,11 +1,12 @@
 import type { Static, TSchema } from '@sinclair/typebox'
 import { createError, H3Event, readBody } from 'h3'
 import { betterAjvErrors } from '@apideck/better-ajv-errors'
+import type { useValidatorOptions } from './utils'
 import { useValidator } from './utils'
 
-export async function validateBody<T extends TSchema> (event: H3Event, schema: T) {
+export async function validateBody<T extends TSchema> (event: H3Event, schema: T, options: useValidatorOptions = { includeAjvFormats: false }) {
   const body = await readBody(event)
-  const validate = useValidator().compile(schema)
+  const validate = useValidator(options).compile(schema)
 
   if (!validate(body)) {
     const betterErrors = betterAjvErrors({ schema, data: body, errors: validate.errors, basePath: 'body' })

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,11 +1,12 @@
 import type { Static, TSchema } from '@sinclair/typebox'
 import { createError, getQuery, H3Event } from 'h3'
 import { betterAjvErrors } from '@apideck/better-ajv-errors'
+import type { useValidatorOptions } from './utils'
 import { useValidator } from './utils'
 
-export function validateQuery<T extends TSchema> (event: H3Event, schema: T) {
+export function validateQuery<T extends TSchema> (event: H3Event, schema: T, options: useValidatorOptions = { includeAjvFormats: false }) {
   const query = getQuery(event)
-  const validate = useValidator().compile(schema)
+  const validate = useValidator(options).compile(schema)
 
   if (!validate(query)) {
     const betterErrors = betterAjvErrors({ schema, data: query, errors: validate.errors, basePath: 'query' })

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,13 +1,66 @@
 import Ajv from 'ajv'
+import addFormats from 'ajv-formats'
+import { TypeGuard } from '@sinclair/typebox/guard'
+import { Value } from '@sinclair/typebox/value'
+
+export interface useValidatorOptions {
+  includeAjvFormats: boolean
+}
 
 let instance: Ajv
+let instanceWithFormats: Ajv
 
-export function useValidator () {
-  if (!instance) {
+function schemaOf (schemaOf: string, value: unknown, schema: unknown) {
+  switch (schemaOf) {
+    case 'Constructor':
+      return TypeGuard.TConstructor(schema) && Value.Check(schema, value) // not supported
+    case 'Function':
+      return TypeGuard.TFunction(schema) && Value.Check(schema, value) // not supported
+    case 'Date':
+      return TypeGuard.TDate(schema) && Value.Check(schema, value)
+    case 'Promise':
+      return TypeGuard.TPromise(schema) && Value.Check(schema, value) // not supported
+    case 'Uint8Array':
+      return TypeGuard.TUint8Array(schema) && Value.Check(schema, value)
+    case 'Undefined':
+      return TypeGuard.TUndefined(schema) && Value.Check(schema, value) // not supported
+    case 'Void':
+      return TypeGuard.TVoid(schema) && Value.Check(schema, value)
+    default:
+      return false
+  }
+}
+
+export function useValidator (options?: useValidatorOptions) {
+  if (options?.includeAjvFormats) {
+    if (!instanceWithFormats) {
+      instanceWithFormats = addFormats(new Ajv({
+        keywords: ['kind', 'modifier']
+      }), {
+        mode: 'fast',
+        formats: [
+          'date-time',
+          'time',
+          'date',
+          'email',
+          'uri',
+          'uri-reference'
+        ] // Only adding formats that are simplified by fast mode and are "relatively" safe. See https://ajv.js.org/guide/formats.html for details.
+      })
+        .addKeyword({ type: 'object', keyword: 'instanceOf', validate: schemaOf })
+        .addKeyword({ type: 'null', keyword: 'typeOf', validate: schemaOf })
+        .addKeyword('exclusiveMinimumTimestamp')
+        .addKeyword('exclusiveMaximumTimestamp')
+        .addKeyword('minimumTimestamp')
+        .addKeyword('maximumTimestamp')
+        .addKeyword('minByteLength')
+        .addKeyword('maxByteLength')
+    }
+    return instanceWithFormats
+  } else if (!instance) {
     instance = new Ajv({
       keywords: ['kind', 'modifier']
     })
   }
-
   return instance
 }

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -16,10 +16,30 @@ describe('validateQuery', () => {
     required: Type.String()
   })
 
+  const querySchemaWithExtendedTypes = Type.Object({
+    date: Type.String({ format: 'date' }),
+    time: Type.String({ format: 'time' }),
+    dateTime: Type.String({ format: 'date-time' })
+  })
+
+  const queryWithExtendedTypes = {
+    date: '2018-11-13',
+    time: '20:20:39+00:00',
+    dateTime: '2018-11-13T20:20:39+00:00'
+  }
+
   it('returns 200 OK if query matches validation schema', async () => {
     app.use('/validate', eventHandler(req => validateQuery(req, querySchema)))
 
     const res = await request.get('/validate?required')
+
+    expect(res.status).toEqual(200)
+  })
+
+  it('returns 200 OK if query matches extended validation schema', async () => {
+    app.use('/validate', eventHandler(req => validateQuery(req, querySchemaWithExtendedTypes, { includeAjvFormats: true })))
+
+    const res = await request.get('/validate').query(queryWithExtendedTypes)
 
     expect(res.status).toEqual(200)
   })
@@ -35,5 +55,22 @@ describe('validateQuery', () => {
         statusMessage: "query must have required property 'required'"
       })
     )
+  })
+
+  it('throws 500 if no options for extended schema are present', async () => {
+    app.use('/validate', eventHandler(req => validateQuery(req, querySchemaWithExtendedTypes)))
+
+    const res = await request.get('/validate').query(queryWithExtendedTypes)
+
+    expect(res.statusCode).toEqual(500)
+  })
+
+  it('throws 400 Bad Request if query does not match validation schema with extended schema options', async () => {
+    app.use('/validate', eventHandler(req => validateQuery(req, querySchemaWithExtendedTypes, { includeAjvFormats: true })))
+
+    const res = await request.get('/validate').query({ date: '2018-11-13T20:20:39+00:00', time: '20:20', dateTime: '2018-11-13T20:20:39' })
+
+    expect(res.body.statusMessage).toEqual('property \'date\' must match format \'date\'')
+    expect(res.statusCode).toEqual(400)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strictNullChecks": true
   },
   "include": [
     "src"


### PR DESCRIPTION
- Added `useValidatorOptions` type for the user to define extra options
- Added the option `includeAjvFormats` to include extended ajv formats, also implemented by typebox 0.25+
- Added tests for body and query validator to test extended formats

The current behavior of throwing a 500 when extended schema option was just kept and added to the tests. We should evaluate error handling for this in the future.
`strictNullChecks` was added to tsconfig to properly generate dynamic type checks in VSCode, as warned.
As a .eslintrc was already existend, I also added the vscode configuration that implements auto format on save for this eslint config and the minimal possible options for the ts formatter to avoid conflicts.