### PR TITLE
feat: add `allowCoerceTypes` ajv setting for validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }

--- a/src/body.ts
+++ b/src/body.ts
@@ -4,7 +4,7 @@ import { betterAjvErrors } from '@apideck/better-ajv-errors'
 import type { useValidatorOptions } from './utils'
 import { useValidator } from './utils'
 
-export async function validateBody<T extends TSchema> (event: H3Event, schema: T, options: useValidatorOptions = { includeAjvFormats: false }) {
+export async function validateBody<T extends TSchema> (event: H3Event, schema: T, options: useValidatorOptions = { includeAjvFormats: false, allowCoerceTypes: false }) {
   const body = await readBody(event)
   const validate = useValidator(options).compile(schema)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { Type } from '@sinclair/typebox'
 
 export * from './body'
 export * from './query'
+export * from './routerParams'

--- a/src/query.ts
+++ b/src/query.ts
@@ -4,7 +4,7 @@ import { betterAjvErrors } from '@apideck/better-ajv-errors'
 import type { useValidatorOptions } from './utils'
 import { useValidator } from './utils'
 
-export function validateQuery<T extends TSchema> (event: H3Event, schema: T, options: useValidatorOptions = { includeAjvFormats: false }) {
+export function validateQuery<T extends TSchema> (event: H3Event, schema: T, options: useValidatorOptions = { includeAjvFormats: false, allowCoerceTypes: false }) {
   const query = getQuery(event)
   const validate = useValidator(options).compile(schema)
 

--- a/src/routerParams.ts
+++ b/src/routerParams.ts
@@ -1,0 +1,17 @@
+import type { Static, TSchema } from '@sinclair/typebox'
+import { createError, H3Event, getRouterParams } from 'h3'
+import { betterAjvErrors } from '@apideck/better-ajv-errors'
+import type { useValidatorOptions } from './utils'
+import { useValidator } from './utils'
+
+export function validateRouterParams<T extends TSchema> (event: H3Event, schema: T, options: useValidatorOptions = { includeAjvFormats: false, allowCoerceTypes: false }) {
+  const query = getRouterParams(event)
+  const validate = useValidator(options).compile(schema)
+
+  if (!validate(query)) {
+    const betterErrors = betterAjvErrors({ schema, data: query, errors: validate.errors, basePath: 'query' })
+    throw createError({ statusCode: 400, statusMessage: betterErrors[0].message })
+  }
+
+  return query as Static<T>
+}

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -4,7 +4,7 @@ import { TypeGuard } from '@sinclair/typebox/guard'
 import { Value } from '@sinclair/typebox/value'
 
 export interface useValidatorOptions {
-  includeAjvFormats: boolean,
+  includeAjvFormats: boolean
   allowCoerceTypes: boolean
 }
 

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -4,7 +4,8 @@ import { TypeGuard } from '@sinclair/typebox/guard'
 import { Value } from '@sinclair/typebox/value'
 
 export interface useValidatorOptions {
-  includeAjvFormats: boolean
+  includeAjvFormats: boolean,
+  allowCoerceTypes: boolean
 }
 
 let instance: Ajv
@@ -35,7 +36,8 @@ export function useValidator (options?: useValidatorOptions) {
   if (options?.includeAjvFormats) {
     if (!instanceWithFormats) {
       instanceWithFormats = addFormats(new Ajv({
-        keywords: ['kind', 'modifier']
+        keywords: ['kind', 'modifier'],
+        coerceTypes: options?.allowCoerceTypes
       }), {
         mode: 'fast',
         formats: [

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -61,7 +61,8 @@ export function useValidator (options?: useValidatorOptions) {
     return instanceWithFormats
   } else if (!instance) {
     instance = new Ajv({
-      keywords: ['kind', 'modifier']
+      keywords: ['kind', 'modifier'],
+      coerceTypes: options?.allowCoerceTypes
     })
   }
   return instance


### PR DESCRIPTION
The purpose of this setting is to allow typed data to be validated in query strings by utilizing AJVs coerceTypes feature